### PR TITLE
Adding a way to externally refresh the pages

### DIFF
--- a/src/scripts/03-params.js
+++ b/src/scripts/03-params.js
@@ -339,6 +339,11 @@ app.factory('ngTableParams', ['$q', function ($q) {
                 settings.$scope.pages = self.generatePagesArray(self.page(), self.total(), self.count());
             });
         };
+        
+        this.reloadPages = function () {
+            var self = this;
+            settings.$scope.pages = self.generatePagesArray(self.page(), self.total(), self.count());
+        };
 
         var params = this.$params = {
             page: 1,


### PR DESCRIPTION
I am loading data externally which populates correctly in the table but when I first load the data via ajax and set the total on the ngTableParams the pages collection is not updated.  It would be nice if it were updated automatically but at the least a method to trigger the reload should be added.
