### PR TITLE
Fix issue when compiling with Google Closure compiler

### DIFF
--- a/ng-table.src.js
+++ b/ng-table.src.js
@@ -301,7 +301,7 @@ app.factory('ngTableParams', ['$q', '$log', function ($q, $log) {
                 minPage = Math.max(2, currentPage - maxPivotPages);
                 maxPage = Math.min(numPages - 1, currentPage + maxPivotPages * 2 - (currentPage - minPage));
                 minPage = Math.max(2, minPage - (maxPivotPages * 2 - (maxPage - minPage)));
-                i = minPage;
+                var i = minPage;
                 while (i <= maxPage) {
                     if ((i === minPage && i !== 2) || (i === maxPage && i !== numPages - 1)) {
                         pages.push({


### PR DESCRIPTION
When compiling ng-table with Google's closure compiler, the code would not paginate. The `while` loop below the declaration of `i` was converted to a `for` loop. After declaring `i` as variable and recompiling, ng-table works as expected.
