### PR TITLE
Remove sorting param from tableParams specs

### DIFF
--- a/test/tableParamsSpec.js
+++ b/test/tableParamsSpec.js
@@ -137,9 +137,7 @@ describe('ngTableParams', function () {
     }));
 
     it('ngTableParams test settings', inject(function (ngTableParams) {
-        var params = new ngTableParams({
-            'sorting[name]': 'asc'
-        });
+        var params = new ngTableParams();
 
         expect(params.settings()).toEqual({
             $scope: null,
@@ -150,11 +148,7 @@ describe('ngTableParams', function () {
             getGroups: params.getGroups
         });
 
-        params = new ngTableParams({
-            'sorting[name]': 'asc'
-        }, {
-            total: 100
-        });
+        params = new ngTableParams({}, { total: 100 });
 
         expect(params.settings()).toEqual({
             $scope: null,
@@ -167,9 +161,7 @@ describe('ngTableParams', function () {
     }));
 
     it('ngTableParams test getData', inject(function ($q, ngTableParams) {
-        var params = new ngTableParams({
-            'sorting[name]': 'asc'
-        });
+        var params = new ngTableParams();
         $defer = $q.defer();
         $defer.promise.then(function(data) {
             expect(data).toEqual([]);
@@ -178,9 +170,7 @@ describe('ngTableParams', function () {
     }));
 
     it('ngTableParams test grouping', inject(function ($q, ngTableParams) {
-        var params = new ngTableParams({
-            'sorting[name]': 'asc'
-        });
+        var params = new ngTableParams();
         params.getData = function ($defer) {
             $defer.resolve(data);
         };


### PR DESCRIPTION
I don't think specifying a sorting param is necessary for these tests, but I could be wrong. What's the purpose of including that parameter when we're not explicitly testing it?
