### PR TITLE
Pagination in a <tfoot> element instead of a <div>

### DIFF
--- a/src/scripts/05-directive.js
+++ b/src/scripts/05-directive.js
@@ -133,14 +133,14 @@ app.directive('ngTable', ['$compile', '$q', '$parse',
                             pagination: (attrs.templatePagination ? attrs.templatePagination : 'ng-table/pager.html')
                         };
                         var headerTemplate = thead.length > 0 ? thead : angular.element(document.createElement('thead')).attr('ng-include', 'templates.header');
-                        var paginationTemplate = angular.element(document.createElement('div')).attr('ng-include', 'templates.pagination');
+                        var paginationTemplate = angular.element(document.createElement('tfoot')).attr('ng-include', 'templates.pagination');
                         element.find('thead').remove();
                         var tbody = element.find('tbody');
                         element.prepend(headerTemplate);
                         $compile(headerTemplate)(scope);
                         $compile(paginationTemplate)(scope);
                         element.addClass('ng-table');
-                        return element.after(paginationTemplate);
+                        return tbody.after(paginationTemplate);
                     }
                 };
             }


### PR DESCRIPTION
This PR could be discussed, but I think it's prettier this way :

Pagination should be in <tfoot> element instead of beeing throwed in a div that has no connexion with the table.

Haven't build the minified and src because I do not know how this is beeing done.
