### PR TITLE
Sorting param as Object instead if String

### DIFF
--- a/src/scripts/03-params.js
+++ b/src/scripts/03-params.js
@@ -170,7 +170,7 @@ app.factory('ngTableParams', ['$q', '$log', function ($q, $log) {
          * @returns {Array} Return true if field sorted by direction
          */
         this.isSortBy = function (field, direction) {
-            return angular.isDefined(params.sorting[field]) && angular.isEqual(params.sorting[field], direction);
+            return angular.isDefined(params.sorting[field]) && angular.equals(params.sorting[field], direction);
         };
 
         /**

--- a/src/scripts/03-params.js
+++ b/src/scripts/03-params.js
@@ -170,7 +170,7 @@ app.factory('ngTableParams', ['$q', '$log', function ($q, $log) {
          * @returns {Array} Return true if field sorted by direction
          */
         this.isSortBy = function (field, direction) {
-            return angular.isDefined(params.sorting[field]) && params.sorting[field] == direction;
+            return angular.isDefined(params.sorting[field]) && angular.isEqual(params.sorting[field], direction);
         };
 
         /**


### PR DESCRIPTION
I had to implement a more complex sorting, so i needed to use an object instead of a simple String. This broke the == comperator used in the source code. 

Switching to angular.equals() both methods are supported.

Kind Regards