### PR TITLE
Column detect fix

### DIFF
--- a/src/scripts/05-directive.js
+++ b/src/scripts/05-directive.js
@@ -39,7 +39,7 @@ app.directive('ngTable', ['$compile', '$q', '$parse',
                 if (!row) {
                     return;
                 }
-                angular.forEach(row.find('td,tr'), function (item) {
+                angular.forEach(row.find('td,th'), function (item) {
                     var el = angular.element(item);
                     if (el.attr('ignore-cell') && 'true' === el.attr('ignore-cell')) {
                         return;

--- a/src/scripts/05-directive.js
+++ b/src/scripts/05-directive.js
@@ -39,7 +39,7 @@ app.directive('ngTable', ['$compile', '$q', '$parse',
                 if (!row) {
                     return;
                 }
-                angular.forEach(row.find('td'), function (item) {
+                angular.forEach(row.find('td,tr'), function (item) {
                     var el = angular.element(item);
                     if (el.attr('ignore-cell') && 'true' === el.attr('ignore-cell')) {
                         return;


### PR DESCRIPTION
Allow ng-table to detect columns that are defined with  both ```<th>``` and ```<td>```.

Previously with custom headers, ng-table would not detect columns that were defined with ```<th></th>``` inside a ```<thead></thead>``` block.