### PR TITLE
AMD definition fix

### DIFF
--- a/ng-table.js
+++ b/ng-table.js
@@ -8,7 +8,7 @@
     } else {
         return factory(angular);
     }
-}(angular || null, function(angular) {
+}(typeof(angular) === 'undefined' ? null : angular, function(angular) {
     'use strict';
 /**
  * ngTable: Table + Angular JS


### PR DESCRIPTION
"angular || null" will return an error if angular is not defined, not null as expected

this change makes ng-table compatible with requireJS (bug appeared when ng-table was loaded before angular, that can happen at random)
