### PR TITLE
Do not reload if not initialized

### DIFF
--- a/ng-table.js
+++ b/ng-table.js
@@ -395,6 +395,10 @@ app.factory('ngTableParams', ['$q', '$log', function ($q, $log) {
             var $defer = $q.defer(),
                 self = this;
 
+            if (!settings.$scope) {
+                return;
+            }
+
             settings.$loading = true;
             if (settings.groupBy) {
                 settings.getGroups($defer, settings.groupBy, this);


### PR DESCRIPTION
I've had the scenario come up a couple times where my data model is updated before ng-table is "ready". This prevents something from triggering `reload` and having a javascript error. 