### PR TITLE
#284 Missing AMD definition fix in the 01-into.js.

### DIFF
--- a/src/scripts/01-intro.js
+++ b/src/scripts/01-intro.js
@@ -8,5 +8,5 @@
     } else {
         return factory(angular);
     }
-}(angular || null, function(angular) {
+}(typeof(angular) === 'undefined' ? null : angular, function(angular) {
     'use strict';


### PR DESCRIPTION
This is a missing piece of the fix for #284. 01-intro.js should also be fixed otherwise this AMD definition will still be incorrect upon the project build (grunt concat task).
