### PR TITLE
Pagination related Bug: settings.total can be a function! No page button will be displayed in this case.

### DIFF
--- a/ng-table.js
+++ b/ng-table.js
@@ -159,7 +159,14 @@ app.factory('ngTableParams', ['$q', '$log', function ($q, $log) {
          * @returns {Object|Number} Current page or `this`
          */
         this.total = function (total) {
-            return angular.isDefined(total) ? this.settings({'total': total}) : settings.total;
+            //return angular.isDefined(total) ? this.settings({ 'total': total }) : settings.total;
+            if (angular.isDefined(total)) {
+                return this.settings({ 'total': total });
+            }
+            if (angular.isFunction(settings.total))
+                return settings.total();
+            else
+                return settings.total;
         };
 
         /**
@@ -298,8 +305,6 @@ app.factory('ngTableParams', ['$q', '$log', function ($q, $log) {
          */
         this.generatePagesArray = function (currentPage, totalItems, pageSize) {
             var maxBlocks, maxPage, maxPivotPages, minPage, numPages, pages;
-            if (angular.isFunction(totalItems))
-                totalItems = totalItems();
             maxBlocks = 11;
             pages = [];
             numPages = Math.ceil(totalItems / pageSize);


### PR DESCRIPTION
Related to the Sample #14 'Table with external control of data', when run alone it will not show the pagination section: totalItems is assigned with settings.total, which in this case is a function; this causes numPages to be NaN.

A quick fix is to check if totalItems is a function inside the generatePagesArray function and execute it.

Honestly I have no idea why it works in the sample preview and in the plunkr.
