### PR TITLE
Relax angular dependency so that 1.3.0-beta can be installed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,9 +10,9 @@
     "src"
   ],
   "dependencies": {
-    "angular": "~1.2.9"
+    "angular": "~1"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.9"
+    "angular-mocks": "~1"
   }
 }


### PR DESCRIPTION
I am using `ng-table` through http://rails-assets.org (I have `rails-assets-ng-table` entry in my `Gemfile`). I found it impossible to upgrade Angular to `1.3.0.beta10` because of `ng-table` dependency on Angular 1.2. I've done some tests and looks like `ng-table` is working good with Angular 1.3.0.
