### PR TITLE
Update 04-controller.js, `params` may be inherited

### DIFF
--- a/src/scripts/04-controller.js
+++ b/src/scripts/04-controller.js
@@ -16,7 +16,7 @@
 var ngTableController = ['$scope', 'ngTableParams', '$timeout', function ($scope, ngTableParams, $timeout) {
     $scope.$loading = false;
 
-    if (!$scope.params) {
+    if (!($scope.params instanceof ngTableParams)) {
         $scope.params = new ngTableParams();
     }
     $scope.params.settings().$scope = $scope;


### PR DESCRIPTION
`params` model may be inherited from parent scope, look at instance rather than just truthiness (line 19)

P.S. edited on GitHub, it seems to have added a newline to the end of the file (line 59)