### PR TITLE
Add ngdocs support to Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,8 @@ module.exports = function (grunt) {
 
     require('load-grunt-tasks')(grunt);
 
+    grunt.loadNpmTasks('grunt-ngdocs');
+
     grunt.registerTask('serve', ['connect:serve', 'watch']);
 
     grunt.registerTask('dev', [
@@ -23,6 +25,13 @@ module.exports = function (grunt) {
 
     grunt.initConfig({
         cmpnt: grunt.file.readJSON('bower.json'),
+        ngdocs: {
+            options:{ dest: 'docs' },
+            api:{
+                src:['src/**/*.js'],
+                title:'API Documentation'
+            }
+        },
         banner: '/*! ngTable v<%= cmpnt.version %> by Vitalii Savchuk(esvit666@gmail.com) - ' +
             'https://github.com/esvit/ng-table - New BSD License */\n',
         clean: {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "karma-ng-html2js-preprocessor": "*",
         "coveralls": "",
         "karma-coverage": "~0.1.0",
-        "grunt-coffee-build": "~1.4.12"
+        "grunt-coffee-build": "~1.4.12",
+        "grunt-ngdocs": "~0.2.2"
     },
     "scripts": {
         "test": "karma start --single-run --no-auto-watch"

--- a/src/scripts/02-app.js
+++ b/src/scripts/02-app.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ngdoc module
+ * @ngdoc overview
  * @name ngTable
  * @description ngTable: Table + Angular JS
  * @example


### PR DESCRIPTION
I noticed you had `@ngdoc` statements in your codebase, but ngdocs wasn't in your Gruntfile. I added ngdocs to the Gruntfile and fixed a syntax error in one of the `@ngdoc` statements. 

To create documentation, simply run `grunt ngdocs`. This will populate the docs directory with all your doc pages (assuming you have already run `npm install`). 