### PR TITLE
feat(filters): url to filter template defined by the filter value rather...

### DIFF
--- a/examples/demo20.html
+++ b/examples/demo20.html
@@ -44,12 +44,8 @@
         <tr class="ng-table-filters" ng-init="tableParams">
             <th ng-repeat="column in columns" ng-show="column.visible" class="filter">
                 <div ng-repeat="(name, filter) in column.filter">
-                    <div ng-if="column.filterTemplateURL" ng-show="column.filterTemplateURL">
-                        <div ng-include="column.filterTemplateURL"></div>
-                    </div>
-                    <div ng-if="!column.filterTemplateURL" ng-show="!column.filterTemplateURL">
-                        <div ng-include="'ng-table/filters/' + filter + '.html'"></div>
-                    </div>
+                    <div ng-if="filter.indexOf('/') !== -1" ng-include="filter"></div>
+                    <div ng-if="filter.indexOf('/') === -1" ng-include="'ng-table/filters/' + filter + '.html'"></div>
                 </div>
             </th>
         </tr>

--- a/src/ng-table/header.html
+++ b/src/ng-table/header.html
@@ -17,12 +17,8 @@
 <tr ng-show="show_filter" class="ng-table-filters">
     <th data-title-text="{{parse(column.title)}}" ng-repeat="column in $columns" ng-show="column.show(this)" class="filter">
         <div ng-repeat="(name, filter) in column.filter">
-            <div ng-if="column.filterTemplateURL" ng-show="column.filterTemplateURL">
-                <div ng-include="column.filterTemplateURL"></div>
-            </div>
-            <div ng-if="!column.filterTemplateURL" ng-show="!column.filterTemplateURL">
-                <div ng-include="'ng-table/filters/' + filter + '.html'"></div>
-            </div>
+            <div ng-if="filter.indexOf('/') !== -1" ng-include="filter"></div>
+            <div ng-if="filter.indexOf('/') === -1" ng-include="'ng-table/filters/' + filter + '.html'"></div>
         </div>
     </th>
 </tr>

--- a/src/scripts/05-directive.js
+++ b/src/scripts/05-directive.js
@@ -63,16 +63,11 @@ app.directive('ngTable', ['$compile', '$q', '$parse',
                     var parsedTitle = parsedAttribute('title', ' '),
                         headerTemplateURL = parsedAttribute('header', false),
                         filter = parsedAttribute('filter', false)(),
-                        filterTemplateURL = false,
                         filterName = false;
 
                     if (filter && filter.$$name) {
                         filterName = filter.$$name;
                         delete filter.$$name;
-                    }
-                    if (filter && filter.templateURL) {
-                        filterTemplateURL = filter.templateURL;
-                        delete filter.templateURL;
                     }
 
                     var titleExpr = getAttrValue('title');
@@ -86,7 +81,6 @@ app.directive('ngTable', ['$compile', '$q', '$parse',
                         sortable: parsedAttribute('sortable', false),
                         'class': parsedAttribute('header-class', ''),
                         filter: filter,
-                        filterTemplateURL: filterTemplateURL,
                         filterName: filterName,
                         headerTemplateURL: headerTemplateURL,
                         filterData: (el.attr("filter-data") ? el.attr("filter-data") : null),

--- a/test/tableSpec.js
+++ b/test/tableSpec.js
@@ -268,7 +268,7 @@ describe('ng-table', function() {
             });
         });
 
-        describe('filter def with optional templateURL', function(){
+        describe('filter def with fully qualified url', function(){
 
             var elm;
             beforeEach(inject(function($compile, NgTableParams) {
@@ -278,7 +278,7 @@ describe('ng-table', function() {
                         '<table ng-table="tableParams" show-filter="true">' +
                         '<tr ng-repeat="user in $data">' +
                         '<td header-class="captureColumn(column)" title="\'Age\'" ' +
-                            'filter="{ \'age\': \'number\', templateURL: \'ng-table/filters/customNum.html\' }">{{user.age}}</td>' +
+                            'filter="{ \'age\': \'ng-table/filters/customNum.html\' }">{{user.age}}</td>' +
                         '</tr>' +
                         '</table>' +
                         '</div>');
@@ -288,16 +288,12 @@ describe('ng-table', function() {
                 scope.$digest();
             }));
 
-            it('should render filter template specified by templateURL', function() {
+            it('should render filter template specified by url', function() {
                 var inputs = elm.find('thead').find('tr').eq(1).find('th').find('input');
                 expect(inputs.length).toBe(1);
 
                 expect(inputs.eq(0).attr('type')).toBe('number');
                 expect(inputs.eq(0).attr('id')).toBe('age');
-            });
-
-            it('should set $column.filterTemplateURL to templateURL value', function () {
-                expect(columnDef.filterTemplateURL).toBe('ng-table/filters/customNum.html');
             });
         });
 


### PR DESCRIPTION
... than a separate templateUrl field

This both simplifies and enhances the api for defining filters:

* A filter value that contains a '/' will now be treated as the url to the filter template
* A filter value *without* a '/' will be considered an alias to a filter defined in the ng-tables/filters folder
* Multiple filters defined by the *same* filter definition can now specify their own template url

BREAKING CHANGE:

* column.filterTemplateURL has been dropped as this is no longer applicable. **Custom** *header.html*
templates will need to change.

Previously:

````
        <tr class="ng-table-filters" ng-init="tableParams">
            <th ng-repeat="column in columns" ng-show="column.visible" class="filter">
                <div ng-repeat="(name, filter) in column.filter">
                    <div ng-if="column.filterTemplateURL" ng-show="column.filterTemplateURL">
                        <div ng-include="column.filterTemplateURL"></div>
                    </div>
                    <div ng-if="!column.filterTemplateURL" ng-show="!column.filterTemplateURL">
                        <div ng-include="'ng-table/filters/' + filter + '.html'"></div>
                    </div>
                </div>
            </th>
        </tr>
````
... now becomes:

````
        <tr class="ng-table-filters" ng-init="tableParams">
            <th ng-repeat="column in columns" ng-show="column.visible" class="filter">
                <div ng-repeat="(name, filter) in column.filter">
                    <div ng-if="filter.indexOf('/') !== -1" ng-include="filter"></div>
                    <div ng-if="filter.indexOf('/') === -1" ng-include="'ng-table/filters/' + filter + '.html'"></div>
                </div>
            </th>
        </tr>
````

* Specifying the url to a filter template has changed.

Previously:

````
<td filter="{ 'name': 'text', templateURL: 'path/to/textFilter.html'}"</td>
````

... now becomes:

````
<td filter="{ 'name': 'path/to/textFilter.html'}"</td>
````

* Multiple filters defined by the *same* filter definition will now specify their own url.

Previously:

````
<td filter="{
    'fname': 'text',
    'lname': 'text',
    templateURL: 'path/to/textFilter.html'}"</td>
````

... now becomes:

````
<td filter="{
    'fname': 'path/to/textFilter.html',
    'lname': 'path/to/textFilter.html'}"</td>
````