### PR TITLE
refactor(filters): name of filter input defined by the filter key rather...

### DIFF
--- a/src/ng-table/filters/select-multiple.html
+++ b/src/ng-table/filters/select-multiple.html
@@ -3,5 +3,5 @@
         multiple ng-multiple="true"
         ng-model="params.filter()[name]"
         ng-show="filter == 'select-multiple'"
-        class="filter filter-select-multiple form-control" name="{{column.filterName}}">
+        class="filter filter-select-multiple form-control" name="{{name}}">
 </select>

--- a/src/ng-table/filters/select.html
+++ b/src/ng-table/filters/select.html
@@ -2,5 +2,5 @@
         ng-disabled="$filterRow.disabled"
         ng-model="params.filter()[name]"
         ng-show="filter == 'select'"
-        class="filter filter-select form-control" name="{{column.filterName}}">
+        class="filter filter-select form-control" name="{{name}}">
 </select>

--- a/src/ng-table/filters/text.html
+++ b/src/ng-table/filters/text.html
@@ -1,1 +1,1 @@
-<input type="text" name="{{column.filterName}}" ng-disabled="$filterRow.disabled" ng-model="params.filter()[name]" ng-if="filter == 'text'" class="input-filter form-control" />
+<input type="text" name="{{name}}" ng-disabled="$filterRow.disabled" ng-model="params.filter()[name]" ng-if="filter == 'text'" class="input-filter form-control" />

--- a/src/scripts/05-directive.js
+++ b/src/scripts/05-directive.js
@@ -62,13 +62,7 @@ app.directive('ngTable', ['$compile', '$q', '$parse',
 
                     var parsedTitle = parsedAttribute('title', ' '),
                         headerTemplateURL = parsedAttribute('header', false),
-                        filter = parsedAttribute('filter', false)(),
-                        filterName = false;
-
-                    if (filter && filter.$$name) {
-                        filterName = filter.$$name;
-                        delete filter.$$name;
-                    }
+                        filter = parsedAttribute('filter', false)();
 
                     var titleExpr = getAttrValue('title');
                     if (titleExpr){
@@ -81,7 +75,6 @@ app.directive('ngTable', ['$compile', '$q', '$parse',
                         sortable: parsedAttribute('sortable', false),
                         'class': parsedAttribute('header-class', ''),
                         filter: filter,
-                        filterName: filterName,
                         headerTemplateURL: headerTemplateURL,
                         filterData: (el.attr("filter-data") ? el.attr("filter-data") : null),
                         show: (el.attr("ng-show") ? function(scope) {

--- a/test/tableSpec.js
+++ b/test/tableSpec.js
@@ -205,7 +205,7 @@ describe('ng-table', function() {
                         '<table ng-table="tableParams" show-filter="true">' +
                         '<tr ng-repeat="user in $data">' +
                         '<td header-class="captureColumn(column)" title="\'Name\'" ' +
-                            'filter="{ \'name\': \'text\' }">{{user.name}}</td>' +
+                            'filter="{ \'username\': \'text\' }">{{user.name}}</td>' +
                         '</tr>' +
                         '</table>' +
                         '</div>');
@@ -222,10 +222,11 @@ describe('ng-table', function() {
                 expect(inputs.length).toBe(1);
                 expect(inputs.eq(0).attr('type')).toBe('text');
                 expect(inputs.eq(0).attr('ng-model')).not.toBeUndefined();
+                expect(inputs.eq(0).attr('name')).toBe('username');
             });
 
             it('should databind ngTableParams.filter to filter input', function () {
-                scope.tableParams.filter()['name'] = 'my name is...';
+                scope.tableParams.filter()['username'] = 'my name is...';
                 scope.$digest();
 
                 var input = elm.find('thead').find('tr').eq(1).find('th').find('input');
@@ -235,36 +236,7 @@ describe('ng-table', function() {
             it('should make filter def available on $column', function () {
                 expect(columnDef).toBeDefined();
                 expect(columnDef.filter).toBeDefined();
-                expect(columnDef.filter['name']).toBe('text');
-            });
-        });
-
-        describe('filter def with optional $$name', function(){
-
-            var elm;
-            beforeEach(inject(function($compile, NgTableParams) {
-                elm = angular.element(
-                        '<div>' +
-                        '<table ng-table="tableParams" show-filter="true">' +
-                        '<tr ng-repeat="user in $data">' +
-                        '<td header-class="captureColumn(column)" title="\'Name\'" ' +
-                            'filter="{ \'name\': \'text\', $$name: \'username\' }">{{user.name}}</td>' +
-                        '</tr>' +
-                        '</table>' +
-                        '</div>');
-
-                $compile(elm)(scope);
-                scope.tableParams = new NgTableParams({}, {});
-                scope.$digest();
-            }));
-
-            it('should render filter input with name set to $$name value', function() {
-                var input = elm.find('thead').find('tr').eq(1).find('th').find('input');
-                expect(input.attr('name')).toBe('username');
-            });
-
-            it('should set $column.filterName to $$name value', function () {
-                expect(columnDef.filterName).toBe('username');
+                expect(columnDef.filter['username']).toBe('text');
             });
         });
 


### PR DESCRIPTION
... than a separate $$name field

Now a filter input's name is set to the filter key. Eg:

Given: `<td filter="{'username': 'text'}"</td>`
Results in the filter input: `<input name='username'/>`

Previously:

* Unless $$name was supplied, a filter input's name was incorrectly set to 'false'
* When $$name was supplied, multiple filters defined by the *same* filter definition would share the same name

BREAKING CHANGE:

* $$name field on filter definitions is not supported.

Previously:

````
<td filter="{'username': 'text', $$name: 'username'}"</td>
````
... now becomes:

````
<td filter="{'username': 'text'}"</td>
````

* column.filterName has been dropped as this is no longer applicable. **Custom** filter templates will need to change.

Previously:

````
        <input type="text" name="{{column.filterName}}"
````
... now becomes:

````
        <input type="text" name="{{name}}"
````

* Multiple filters defined by the *same* filter definition will now render each input with a seperate name.