### PR TITLE
Fix first load with default parameters

### DIFF
--- a/src/scripts/04-controller.js
+++ b/src/scripts/04-controller.js
@@ -43,7 +43,7 @@ function($scope, NgTableParams, $timeout, $parse, $compile, $attrs, $element, ng
 
     $scope.$watch('params.$params', function(newParams, oldParams) {
 
-        if (newParams === oldParams) {
+        if (!isFirstTimeLoad && newParams === oldParams) {
             return;
         }
 


### PR DESCRIPTION
I've found that if the controller contains a tableParams without custom parameters, the function `getData` is not called and no (lazy) row can be displayed.

Here are some snippets adapted from my code:
```html
<table ng-table="indexCtrl.tableParams">
    <thead>
        <tr><th>Id</th><th>Description</th></tr>
    </thead>
    <tbody>
        <tr ng-repeat="entity in $data">
            <td>{{ entity.props.id }}</td>
            <td>{{ entity.props.description }} </td>
        </tr>
    </tbody>
</table>
```
```js
app.controller('IndexController', function() {
    var self = this;
    this.entities = [{ id: 1, description: "first entity" }];
    this.tableParams = new ngTableParams({}, {
        getData: function (deferred, params) {
            return deferred.resolve(self.entities);
        }
    });
});
```

My solution is of course naive, but fix this scenario. The problem is that the watch function is called, but the comparison `newParams === oldParams` is true and `getData` is never called. Another workaround is to set whatever parameters.

Maybe there are better approach, but I'm an Angular newbie for now :)