### PR TITLE
added function to quickly toggle sort based on keyname

### DIFF
--- a/src/scripts/03-params.js
+++ b/src/scripts/03-params.js
@@ -197,6 +197,23 @@ app.factory('NgTableParams', ['$q', '$log', 'ngTableDefaults', function($q, $log
         this.isSortBy = function(field, direction) {
             return angular.isDefined(params.sorting[field]) && angular.equals(params.sorting[field], direction);
         };
+        
+         /**
+         * @ngdoc method
+         * @name ngTable.factory:NgTableParams#getSortClass
+         * @methodOf ngTable.factory:NgTableParams
+         * @description shorthand so you don't have to clutter the template with this
+         *
+         * @param {string} field     Field name
+         */
+        this.getSortClass = function( val )
+        {
+            return {
+                'sort-desc': $scope.tableParams.isSortBy( val , 'asc'),
+                'sort-asc': $scope.tableParams.isSortBy( val , 'desc')
+            }
+        };
+        
 
         /**
          * @ngdoc method

--- a/src/scripts/03-params.js
+++ b/src/scripts/03-params.js
@@ -221,7 +221,7 @@ app.factory('NgTableParams', ['$q', '$log', 'ngTableDefaults', function($q, $log
          * @description toggle the sort of a column (less boilerplate in template)         * 
          */
         this.toggleSort= function(val){
-            this.sorting( val , $scope.tableParams.isSortBy( val , 'asc') ? 'desc' : 'asc')
+            this.sorting( val , $scope.tableParams.isSortBy( val , 'asc') ? 'desc' : 'asc');
         },
 
         /**

--- a/src/scripts/03-params.js
+++ b/src/scripts/03-params.js
@@ -216,6 +216,16 @@ app.factory('NgTableParams', ['$q', '$log', 'ngTableDefaults', function($q, $log
 
         /**
          * @ngdoc method
+         * @name ngTable.factory:NgTableParams#toggleSort
+         * @methodOf ngTable.factory:NgTableParams
+         * @description toggle the sort of a column (less boilerplate in template)         * 
+         */
+        this.toggleSort= function(val){
+            this.sorting( val , $scope.tableParams.isSortBy( val , 'asc') ? 'desc' : 'asc')
+        },
+
+        /**
+         * @ngdoc method
          * @name ngTable.factory:NgTableParams#getData
          * @methodOf ngTable.factory:NgTableParams
          * @description Called when updated some of parameters for get new data
@@ -362,7 +372,7 @@ app.factory('NgTableParams', ['$q', '$log', 'ngTableDefaults', function($q, $log
                     }
                 }
             }
-            return pairs;
+            return pairsso;
         };
 
         /**


### PR DESCRIPTION
This should reduce boilerplate in the template:
     tableParams.sorting({'foo': tableParams.isSortBy('foo', 'asc') ? 'desc' :'asc'})
Becomes
      tableParams.toggleSort('foo');

        /**
         * @ngdoc method
         * @name ngTable.factory:NgTableParams#toggleSort
         * @methodOf ngTable.factory:NgTableParams
         * @description toggle the sort of a column (less boilerplate in template)         * 
         */
        this.toggleSort= function(val){
            this.sorting( val , $scope.tableParams.isSortBy( val , 'asc') ? 'desc' : 'asc')
        },