### PR TITLE
Update ng-table.js

### DIFF
--- a/dist/ng-table.js
+++ b/dist/ng-table.js
@@ -716,19 +716,26 @@ app.directive('ngTable', ['$compile', '$q', '$parse',
                             header: (attrs.templateHeader ? attrs.templateHeader : 'ng-table/header.html'),
                             pagination: (attrs.templatePagination ? attrs.templatePagination : 'ng-table/pager.html')
                         };
-                        var headerTemplate = thead.length > 0 ? thead : angular.element(document.createElement('thead')).attr('ng-include', 'templates.header');
+                        //var headerTemplate = thead.length > 0 ? thead : angular.element(document.createElement('thead')).attr('ng-include', 'templates.header');
                         var paginationTemplate = angular.element(document.createElement('div')).attr({
                             'ng-table-pagination': 'params',
                             'template-url': 'templates.pagination'
                         });
+                        
+                        var headerTemplate = angular.element(document.createElement('thead')).attr('ng-include', 'templates.header');
+                        
+                        if(thead.length > 0) {
+                             element.addClass('ng-table')
+                             .after(paginationTemplate);
+                        	
+                        } else {
+                             element.find('> thead').remove();
+                             element.addClass('ng-table')
+                             .prepend(headerTemplate)
+                             .after(paginationTemplate);
+                            $compile(headerTemplate)(scope);
+                        }
 
-                        element.find('> thead').remove();
-
-                        element.addClass('ng-table')
-                            .prepend(headerTemplate)
-                            .after(paginationTemplate);
-
-                        $compile(headerTemplate)(scope);
                         $compile(paginationTemplate)(scope);
                     }
                 };


### PR DESCRIPTION
Fix the issue when the ngTable if included in another ngRepeat.

When the ng-Table is included within the ng-Repeat block, the repeated ng-tables do not display properly, the table head shows only for last table in the repeat. 

The fix will modify the DOM only if the THEAD is not provided (build from template) else it keeps the DOM as it is instead of removing from DOM and re-adding to DOM

Please see the Before and After fix urls below
Before fix - http://plnkr.co/edit/EaQlsQCgBC1x9NXNRImp?p=preview
After fix - http://plnkr.co/edit/rygqfV0jV0nWTVeGdDld?p=preview
