### PR TITLE
Fixes #625

### DIFF
--- a/src/ng-table/filters/select.html
+++ b/src/ng-table/filters/select.html
@@ -1,4 +1,4 @@
-<select ng-options="data.id as data.title for data in $column.data"
+<select ng-options="data.id as data.title for data in column.data"
         ng-disabled="$filterRow.disabled"
         ng-model="params.filter()[name]"
         ng-show="filter == 'select'"


### PR DESCRIPTION
$column has been renamed to column but still $column is used in select filter which causes empty select to show up as filter. This check-in fixes that so that select filter shows up with data.