### PR TITLE
Add a NgTableParams setting to modify the default "-" value for SELECT filters

### DIFF
--- a/src/scripts/03-params.js
+++ b/src/scripts/03-params.js
@@ -428,7 +428,8 @@ app.factory('NgTableParams', ['$q', '$log', 'ngTableDefaults', function($q, $log
             paginationMinBlocks: 5,
             sortingIndicator: 'span',
             getGroups: this.getGroups,
-            getData: this.getData
+            getData: this.getData,
+            defaultSelectValue: '-'
         };
         angular.extend(settings, ngTableDefaults.settings);
 

--- a/src/scripts/04-controller.js
+++ b/src/scripts/04-controller.js
@@ -110,7 +110,7 @@ function($scope, NgTableParams, $timeout, $parse, $compile, $attrs, $element, ng
                         data = [];
                     } else if (angular.isArray(data)) {
                         data.unshift({
-                            title: '-',
+                            title: $scope.params.settings().defaultSelectValue,
                             id: ''
                         });
                     }

--- a/src/scripts/05-directive.js
+++ b/src/scripts/05-directive.js
@@ -86,7 +86,12 @@ app.directive('ngTable', ['$q', '$parse',
                     scope.$columns = columns = controller.buildColumns(columns);
 
                     controller.setupBindingsToInternalScope(attrs.ngTable);
-                    controller.loadFilterData(columns);
+                    
+                    // this tiny wait gives the defaultSelectValue setting time to be updated
+                    window.setTimeout(function(){
+                        controller.loadFilterData(columns);
+                    }, 1);
+                    
                     controller.compileDirectiveTemplates();
                 };
             }

--- a/test/tableParamsSpec.js
+++ b/test/tableParamsSpec.js
@@ -151,7 +151,8 @@ describe('NgTableParams', function () {
             sortingIndicator : 'span',
             getData: params.getData,
             getGroups: params.getGroups,
-            filterDelay: 750
+            filterDelay: 750,
+            defaultSelectValue: '-'
         });
 
         params = new NgTableParams({}, { total: 100 });
@@ -168,7 +169,8 @@ describe('NgTableParams', function () {
             sortingIndicator : 'span',
             getData: params.getData,
             getGroups: params.getGroups,
-            filterDelay: 750
+            filterDelay: 750,
+            defaultSelectValue: '-'
         });
     }));
 


### PR DESCRIPTION
Adds a "defaultSelectValue" setting to override the default value of "-" on filters that use a SELECT element, specified when creating new NgTableParams.

e.g.
```
var myTableParams = new NgTableParams({
    // params
}, {
    defaultSelectValue: 'Show all'
});
```