### PR TITLE
Pager: Hiding irrelevant page size controls

### DIFF
--- a/src/ng-table/pager.html
+++ b/src/ng-table/pager.html
@@ -1,6 +1,7 @@
 <div class="ng-cloak ng-table-pager" ng-if="params.data.length">
-    <div ng-if="params.settings().counts.length" class="ng-table-counts btn-group pull-right">
+    <div ng-if="params.settings().counts.length && params.total() > params.settings().counts[0]" class="ng-table-counts btn-group pull-right">
         <button ng-repeat="count in params.settings().counts" type="button"
+                ng-if="($index == 0 && params.total() > count) || (params.total() > params.settings().counts[$index - 1])"
                 ng-class="{'active':params.count() == count}"
                 ng-click="params.count(count)" class="btn btn-default">
             <span ng-bind="count"></span>


### PR DESCRIPTION
Page size controls are always displayed even if they are irrelevant to current dataset.  I..e Say we have 10, 20, 50 page size controls.  There is no need to show any when there is only 3 items on the list.  There is also no need to show 50 if there are only 15 items in the list.