### PR TITLE
Only display pagination UL if there are pages

### DIFF
--- a/src/ng-table/pager.html
+++ b/src/ng-table/pager.html
@@ -6,7 +6,7 @@
             <span ng-bind="count"></span>
         </button>
     </div>
-    <ul class="pagination ng-table-pagination">
+    <ul ng-if="pages.length" class="pagination ng-table-pagination">
         <li ng-class="{'disabled': !page.active && !page.current, 'active': page.current}" ng-repeat="page in pages" ng-switch="page.type">
             <a ng-switch-when="prev" ng-click="params.page(page.number)" href="">&laquo;</a>
             <a ng-switch-when="first" ng-click="params.page(page.number)" href=""><span ng-bind="page.number"></span></a>


### PR DESCRIPTION
Only display the pagination UL if there are going to be LI's within it.
This reduced the margins at the bottom of the table in the case where
there are no pages to display.  I'm using the boostrap CSS so i guess you could argue that this is theme specific.  But I thought i would put this up anyway to get your feedback.

The margin i'm talking about is:
![screen shot 2015-07-16 at 4 41 30 pm](https://cloud.githubusercontent.com/assets/2660/8717254/f1bda2c8-2bdc-11e5-93d4-04ba47fabf7e.png)

This is what it looks like after the patch
![screen shot 2015-07-16 at 4 41 13 pm](https://cloud.githubusercontent.com/assets/2660/8717264/02ace742-2bdd-11e5-92fe-a24d77633314.png)