### PR TITLE
fix #574: duplicate thead element on jqlite

### DIFF
--- a/src/scripts/04-controller.js
+++ b/src/scripts/04-controller.js
@@ -89,7 +89,15 @@ function($scope, NgTableParams, $timeout, $parse, $compile, $attrs, $element, ng
             };
             $element.addClass('ng-table');
             var headerTemplate = null;
-            if ($element.find('> thead').length === 0) {
+
+            // $element.find('> thead').length === 0 doesn't work on jqlite
+            var theadFound = false;
+            angular.forEach($element.children, function(e) {
+                if (e.tagName === 'THEAD') {
+                    theadFound = true;
+                }
+            });
+            if (!theadFound) {
                 headerTemplate = angular.element(document.createElement('thead')).attr('ng-include', 'templates.header');
                 $element.prepend(headerTemplate);
             }


### PR DESCRIPTION
Replaced $element.find('> thead') by code that searches
in DOM for direct children. '> head' is not supported by jqlite.