### PR TITLE
refactor pagination: change pager params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <a name="0.8.3"></a>
 # 0.8.3 (2015-08-09)
+## Breaking Changes
 
+- **pagination:** converted paginationMaxBlocks/paginationMinBlocks to use pager settings  
+     pager.minBlocks, pager.maxBlocks for future enhancements
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 <a name="0.8.3"></a>
 # 0.8.3 (2015-08-09)
-## Breaking Changes
 
-- **pagination:** converted paginationMaxBlocks/paginationMinBlocks to use pager settings  
-     pager.minBlocks, pager.maxBlocks for future enhancements
 
 ## Bug Fixes
 

--- a/examples/demo34.html
+++ b/examples/demo34.html
@@ -60,7 +60,7 @@
                         </div>
                         <div class="form-group">
                             <label class="control-label" for="pageSize">Page Size:</label>
-                            <select id="pageSize" class="form-control" ng-model="tableParams.count" ng-model-options="{getterSetter: true }" ng-options="count for count in tableParams.settings().counts">
+                            <select id="pageSize" class="form-control" ng-model="tableParams.count" ng-model-options="{getterSetter: true }" ng-options="count for count in tableParams.settings().pager.counts">
                             </select>
                         </div>
                         <button type="button" class="btn btn-default" ng-click="tableParams.reload()">Reload</button>
@@ -141,7 +141,9 @@
                 count: 100           // count per page
             }, {
                 filterDelay: 0,
-                counts: [50, 100, 500],
+                pager: {
+                    counts: [50, 100, 500]
+                },
                 total: data.length, // length of data
                 getData: function ($defer, params) {
                     // use built-in angular filter

--- a/examples/demo6.html
+++ b/examples/demo6.html
@@ -156,8 +156,8 @@
                         name: 'asc'     // initial sorting
                     }
                 }, {
-                    counts: [5, 10, 15],
                     pager: {
+                        counts: [5, 10, 15],
                         minBlocks: 4,
                         maxBlocks: 9
                     },

--- a/examples/demo6.html
+++ b/examples/demo6.html
@@ -157,7 +157,10 @@
                     }
                 }, {
                     counts: [5, 10, 15],
-                    paginationMaxBlocks: 9,
+                    pager: {
+                        minBlocks: 4,
+                        maxBlocks: 9
+                    },
                     total: 0,           // length of data
                     getData: function (params) {
                         // ajax request to api

--- a/examples/demo7.html
+++ b/examples/demo7.html
@@ -58,7 +58,9 @@
                 total: 1,  // value less than count hide pagination
                 count: 5  // count per page
             }, {
-                counts: [], // hide page counts control
+                pager: {
+                    counts: [] // hide page counts control
+                },
                 getData: function($defer, params) {
                     $defer.resolve(data.slice((params.page() - 1) * params.count(), params.page() * params.count()));
                 }

--- a/src/ng-table/pager.html
+++ b/src/ng-table/pager.html
@@ -1,6 +1,6 @@
 <div class="ng-cloak ng-table-pager" ng-if="params.data.length">
-    <div ng-if="params.settings().counts.length" class="ng-table-counts btn-group pull-right">
-        <button ng-repeat="count in params.settings().counts" type="button"
+    <div ng-if="params.settings().pager.counts.length" class="ng-table-counts btn-group pull-right">
+        <button ng-repeat="count in params.settings().pager.counts" type="button"
                 ng-class="{'active':params.count() == count}"
                 ng-click="params.count(count)" class="btn btn-default">
             <span ng-bind="count"></span>

--- a/src/scripts/ngTableParams.js
+++ b/src/scripts/ngTableParams.js
@@ -325,7 +325,7 @@
                         active: currentPage > 1,
                         current: currentPage === 1
                     });
-                    maxPivotPages = Math.round((settings.paginationMaxBlocks - settings.paginationMinBlocks) / 2);
+                    maxPivotPages = Math.round(((settings.pager.maxBlocks || 11) - (settings.pager.minBlocks || 5)) / 2);
                     minPage = Math.max(2, currentPage - maxPivotPages);
                     maxPage = Math.min(numPages - 1, currentPage + maxPivotPages * 2 - (currentPage - minPage));
                     minPage = Math.max(2, minPage - (maxPivotPages * 2 - (maxPage - minPage)));
@@ -532,8 +532,10 @@
                 filterDelay: 750,
                 counts: [10, 25, 50, 100],
                 interceptors: [],
-                paginationMaxBlocks: 11,
-                paginationMinBlocks: 5,
+                pager: {
+                    maxBlocks: 11,
+                    minBlocks: 5
+                },
                 sortingIndicator: 'span',
                 getDataFnAdaptor: angular.identity,
                 getGroupsFnAdaptor: angular.identity,

--- a/src/scripts/ngTableParams.js
+++ b/src/scripts/ngTableParams.js
@@ -530,9 +530,9 @@
                 total: 0,
                 defaultSort: 'desc',
                 filterDelay: 750,
-                counts: [10, 25, 50, 100],
                 interceptors: [],
                 pager: {
+                    counts: [10, 25, 50, 100],
                     maxBlocks: 11,
                     minBlocks: 5
                 },

--- a/test/ngTableDefaultGetDataSpec.js
+++ b/test/ngTableDefaultGetDataSpec.js
@@ -17,7 +17,7 @@ describe('ngTableDefaultGetData', function () {
 
     beforeEach(inject(function(_ngTableDefaultGetData_, NgTableParams){
         ngTableDefaultGetData = _ngTableDefaultGetData_;
-        tableParams = new NgTableParams({ count: 10}, { counts: [10]});
+        tableParams = new NgTableParams({ count: 10}, { pager: { counts: [10] }});
     }));
 
     it('should be configured to use built-in angular filters', function(){

--- a/test/tableParamsSpec.js
+++ b/test/tableParamsSpec.js
@@ -183,9 +183,9 @@ describe('NgTableParams', function () {
             data: null,
             total: 0,
             defaultSort : 'desc',
-            counts: [10, 25, 50, 100],
             interceptors: [],
             pager: {
+                counts: [10, 25, 50, 100],
                 maxBlocks: 11,
                 minBlocks: 5
             },
@@ -195,18 +195,16 @@ describe('NgTableParams', function () {
             filterDelay: 750
         }));
 
-        params = new NgTableParams({}, { total: 100, counts: [1,2] });
+        params = new NgTableParams({}, { total: 100, pager: { counts: [1,2] }});
 
         expect(params.settings()).toEqual(jasmine.objectContaining({
             $loading: false,
             data: null,
             total: 100,
             defaultSort : 'desc',
-            counts: [1,2],
             interceptors: [],
             pager: {
-                maxBlocks: 11,
-                minBlocks: 5
+                counts: [1,2]
             },
             sortingIndicator : 'span',
             getData: params.getData,
@@ -379,7 +377,9 @@ describe('NgTableParams', function () {
             count: 2
         };
         ngTableDefaults.settings = {
-            counts: []
+            pager: {
+                counts: []
+            }
         };
         var tp = new NgTableParams();
 
@@ -387,7 +387,7 @@ describe('NgTableParams', function () {
         expect(tp.page()).toEqual(1);
 
         var settings = tp.settings();
-        expect(settings.counts.length).toEqual(0);
+        expect(settings.pager.counts.length).toEqual(0);
         expect(settings.interceptors.length).toEqual(0);
         expect(settings.filterDelay).toEqual(750);
 
@@ -1427,7 +1427,7 @@ describe('NgTableParams', function () {
                     actualPublisher = params;
                     actualEventArgs = [newVal, oldVal];
                 });
-                var params = createNgTableParams({ count: 5 }, { counts: [5,10], data: [1,2,3,4,5,6]});
+                var params = createNgTableParams({ count: 5 }, { pager: { counts: [5,10] }, data: [1,2,3,4,5,6]});
 
                 // when
                 params.reload();
@@ -1445,7 +1445,7 @@ describe('NgTableParams', function () {
                     actualPublisher = params;
                     actualEventArgs = [newVal, oldVal];
                 });
-                var params = createNgTableParams({ count: 5 }, { counts: [5,10], data: []});
+                var params = createNgTableParams({ count: 5 }, { pager: { counts: [5,10] }, data: []});
 
                 // when
                 params.reload();
@@ -1461,7 +1461,7 @@ describe('NgTableParams', function () {
                 ngTableEventsChannel.onPagesChanged(function(/*params, newVal, oldVal*/){
                     callCount++;
                 });
-                var params = createNgTableParams({ count: 5 }, { counts: [5,10], data: [1,2,3,4,5,6]});
+                var params = createNgTableParams({ count: 5 }, { pager: { counts: [5,10] }, data: [1,2,3,4,5,6]});
 
                 // when
                 params.reload();
@@ -1480,7 +1480,7 @@ describe('NgTableParams', function () {
                 ngTableEventsChannel.onPagesChanged(function(/*params, newVal, oldVal*/){
                     callCount++;
                 });
-                var params = createNgTableParams({ count: 5 }, { counts: [5,10], data: [1,2,3,4,5,6]});
+                var params = createNgTableParams({ count: 5 }, { pager: { counts: [5,10] }, data: [1,2,3,4,5,6]});
                 params.reload();
                 scope.$digest();
 

--- a/test/tableParamsSpec.js
+++ b/test/tableParamsSpec.js
@@ -185,8 +185,10 @@ describe('NgTableParams', function () {
             defaultSort : 'desc',
             counts: [10, 25, 50, 100],
             interceptors: [],
-            paginationMaxBlocks: 11,
-            paginationMinBlocks: 5,
+            pager: {
+                maxBlocks: 11,
+                minBlocks: 5
+            },
             sortingIndicator : 'span',
             getData: params.getData,
             getGroups: params.getGroups,
@@ -202,8 +204,10 @@ describe('NgTableParams', function () {
             defaultSort : 'desc',
             counts: [1,2],
             interceptors: [],
-            paginationMaxBlocks: 11,
-            paginationMinBlocks: 5,
+            pager: {
+                maxBlocks: 11,
+                minBlocks: 5
+            },
             sortingIndicator : 'span',
             getData: params.getData,
             getGroups: params.getGroups,

--- a/test/tableSpec.js
+++ b/test/tableSpec.js
@@ -753,7 +753,7 @@ describe('ng-table', function() {
 
         it('should reload 1 time with page reset to 1 when binding a new settings data value and changing the filter', function(){
             var settings = {
-                counts: [1],
+                pager: { counts: [1] },
                 data: [{age: 1}, {age: 2}],
                 filterDelay: 100
             };


### PR DESCRIPTION
change paginationMaxBlocks/paginationMinBlocks to use pager settings  pager {minBlocks: 5, maxBlocks: 11} to allow future enhancements of pager. Set defaults to 5,11 if they are undefined.

BREAKING CHANGE tableParams paginationMaxBlocks/paginationMinBlocks are updated to use pager {minBlocks: YY, maxBlocks: XX}

PR 1 as suggested in #656 by @christianacca 
