### PR TITLE
fix(NgTableParams): thisArg for apply on $log functions should be $log

### DIFF
--- a/src/scripts/ngTableParams.js
+++ b/src/scripts/ngTableParams.js
@@ -32,7 +32,7 @@
                 isCommittedDataset = false,
                 log = function() {
                     if (settings.debugMode && $log.debug) {
-                        $log.debug.apply(this, arguments);
+                        $log.debug.apply($log, arguments);
                     }
                 },
                 defaultFilterOptions = {


### PR DESCRIPTION
`$log` may be decorated or replaced by different modules, and therefore
instead of providing `this` in the `$log.debug.apply` call, `$log` itself
should be passed in as the *thisArg* to ensure state needed for replaced
functions is present.