### PR TITLE
Fixing the sample code on intro page.

### DIFF
--- a/views/intro/overview.html
+++ b/views/intro/overview.html
@@ -39,7 +39,7 @@ angular.module("myApp", ["ngTable"]);
 <pre style="margin-top:10px" data-prettycode pretty-lang="js">
 var self = this;
 var data = [{name: "Moroni", age: 50} /*,*/];
-self.tableParams = new NgTableParams({}, { data: data});
+self.tableParams = new NgTableParams({}, { dataset: data});
 </pre>
             </ol>
         </div>


### PR DESCRIPTION
The sample code in the intro page is not working. 

One should use `dataset` as the key for passing static data.

Fixes #706 