### PR TITLE
prevent buildColumns using null

### DIFF
--- a/src/scripts/ngTableDynamic.directive.js
+++ b/src/scripts/ngTableDynamic.directive.js
@@ -62,8 +62,10 @@
                     controller.compileDirectiveTemplates();
 
                     scope.$watchCollection(expr.columns, function (newCols/*, oldCols*/) {
-                        scope.$columns = controller.buildColumns(newCols);
-                        controller.loadFilterData(scope.$columns);
+                        if (newCols) {
+                            scope.$columns = controller.buildColumns(newCols);
+                            controller.loadFilterData(scope.$columns);
+                        }
                     });
                 };
             }


### PR DESCRIPTION
Whenever I use dynamic columns into ngTable, i kept getting this error on first load of ngTable -
TypeError: Cannot read property 'map' of undefined
    at buildColumns (ng-table.js:1189)

The reason is because newCols is null, it throws map error but it doesn't break the table, so this checks make sure newCols aren't null