### PR TITLE
Don't show pager if only one page must be rendered

### DIFF
--- a/src/ng-table/pager.html
+++ b/src/ng-table/pager.html
@@ -1,4 +1,4 @@
-<div class="ng-cloak ng-table-pager" ng-if="params.data.length">
+<div class="ng-cloak ng-table-pager" ng-if="pages.length" >
     <div ng-if="params.settings().counts.length" class="ng-table-counts btn-group pull-right">
         <button ng-repeat="count in params.settings().counts" type="button"
                 ng-class="{'active':params.count() == count}"
@@ -6,7 +6,7 @@
             <span ng-bind="count"></span>
         </button>
     </div>
-    <ul ng-if="pages.length" class="pagination ng-table-pagination">
+    <ul class="pagination ng-table-pagination">
         <li ng-class="{'disabled': !page.active && !page.current, 'active': page.current}" ng-repeat="page in pages" ng-switch="page.type">
             <a ng-switch-when="prev" ng-click="params.page(page.number)" href="">&laquo;</a>
             <a ng-switch-when="first" ng-click="params.page(page.number)" href=""><span ng-bind="page.number"></span></a>


### PR DESCRIPTION
Related to https://github.com/esvit/ng-table/issues/6
Don't show pager div, if table data are empty or one page only must be rendered. Improves UX and layout.