### PR TITLE
do not apply paging when grouping

### DIFF
--- a/src/scripts/ngTableParams.js
+++ b/src/scripts/ngTableParams.js
@@ -696,7 +696,7 @@
                             result = orderByFn(result, orderBy);
                         }
 
-                        return ngTableDefaultGetData.applyPaging(result, params);
+                        return result;
                     }).finally(function(){
                         // restore the real options
                         settings.dataOptions = originalDataOptions;


### PR DESCRIPTION
This fixes the problem described in https://github.com/esvit/ng-table/issues/795 for me. The applied paging breaks the manual setting of `params.total()`. I am using async getData, grouping and pagination. I think my fix will break things for non asyc data but i do not know how to set the right condition. Perhaps someone could help me out here.
