### PR TITLE
Text filter doesn't autocomplete

### DIFF
--- a/src/ng-table/filters/text.html
+++ b/src/ng-table/filters/text.html
@@ -1,2 +1,2 @@
-<input type="text" name="{{name}}" ng-disabled="$filterRow.disabled" ng-model="params.filter()[name]" class="input-filter form-control"
+<input type="text" autocomplete="off" name="{{name}}" ng-disabled="$filterRow.disabled" ng-model="params.filter()[name]" class="input-filter form-control"
        placeholder="{{getFilterPlaceholderValue(filter, name)}}"/>


### PR DESCRIPTION
I don't know if this is the desired performance for others but for me I don't want autocomplete results to show up in the text filter. I have only tested in Firefox but when starting to implement this into my project I noticed that all of my autocomplete results would load as I started typing which obstructed the data below that was getting filtered and I didn't want that.
