### PR TITLE
Allow pagination styling with Bootstrap v4

### DIFF
--- a/src/browser/pager.html
+++ b/src/browser/pager.html
@@ -7,13 +7,13 @@
         </button>
     </div>
     <ul ng-if="pages.length" class="pagination ng-table-pagination">
-        <li ng-class="{'disabled': !page.active && !page.current, 'active': page.current}" ng-repeat="page in pages" ng-switch="page.type">
-            <a ng-switch-when="prev" ng-click="params.page(page.number)" href="">&laquo;</a>
-            <a ng-switch-when="first" ng-click="params.page(page.number)" href=""><span ng-bind="page.number"></span></a>
-            <a ng-switch-when="page" ng-click="params.page(page.number)" href=""><span ng-bind="page.number"></span></a>
-            <a ng-switch-when="more" ng-click="params.page(page.number)" href="">&#8230;</a>
-            <a ng-switch-when="last" ng-click="params.page(page.number)" href=""><span ng-bind="page.number"></span></a>
-            <a ng-switch-when="next" ng-click="params.page(page.number)" href="">&raquo;</a>
+        <li class="page-item" ng-class="{'disabled': !page.active && !page.current, 'active': page.current}" ng-repeat="page in pages" ng-switch="page.type">
+            <a class="page-link" ng-switch-when="prev" ng-click="params.page(page.number)" href="">&laquo;</a>
+            <a class="page-link" ng-switch-when="first" ng-click="params.page(page.number)" href=""><span ng-bind="page.number"></span></a>
+            <a class="page-link" ng-switch-when="page" ng-click="params.page(page.number)" href=""><span ng-bind="page.number"></span></a>
+            <a class="page-link" ng-switch-when="more" ng-click="params.page(page.number)" href="">&#8230;</a>
+            <a class="page-link" ng-switch-when="last" ng-click="params.page(page.number)" href=""><span ng-bind="page.number"></span></a>
+            <a class="page-link" ng-switch-when="next" ng-click="params.page(page.number)" href="">&raquo;</a>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
From the Bootstrap v4 [migration docs](https://v4-alpha.getbootstrap.com/migration/#pagination):
>Explicit classes (`.page-item`, `.page-link`) are now required on the descendants of `.pagination`s