### PR TITLE
feat($browser): Added events to provide the data after it is filtered…

### DIFF
--- a/src/core/ngTableEventsChannel.ts
+++ b/src/core/ngTableEventsChannel.ts
@@ -22,6 +22,8 @@ export function ngTableEventsChannel($rootScope: ng1.IRootScopeService): IEvents
     events = addTableParamsEvent('afterReloadData', events);
     events = addTableParamsEvent('datasetChanged', events);
     events = addTableParamsEvent('pagesChanged', events);
+    events = addTableParamsEvent('afterDataFiltered', events);
+    events = addTableParamsEvent('afterDataSorted', events);
     return events as IEventsChannel;
 
     //////////

--- a/src/core/public-interfaces.ts
+++ b/src/core/public-interfaces.ts
@@ -545,6 +545,18 @@ export interface IEventSelectorFunc {
 export interface IPagesChangedListener {
     (publisher: INgTableParams<any>, newPages: IPageButton[], oldPages: IPageButton[]): any
 }
+/**
+* Signature of the event hander that is registered to receive the *afterDataFiltered* event
+*/
+export interface IAfterDataFilteredListener<T> {
+    (publisher: IDefaultGetData<T>, params: INgTableParams<T>, newData: DataResult<T>[] ): any
+}
+/**
+* Signature of the event hander that is registered to receive the *afterDataSorted* event
+*/
+export interface IAfterDataSortedListener<T> {
+    (publisher: IDefaultGetData<T>, params: INgTableParams<T>, newData: DataResult<T>[] ): any
+}
 
 /**
  * Signature of the function used to explicitly unregister an event handler so that it stops
@@ -647,9 +659,50 @@ export interface IEventsChannel {
      * @return a unregistration function that when called will unregister the `listener`
      */
     onPagesChanged<T>(listener: IPagesChangedListener, eventFilter?: EventSelector<T>): IUnregistrationFunc;
+    /**
+     * Subscribe to receive notification whenever a `ngTableDefaultGetData` instance filters data
+     * Optionally supply an `eventFilter` to restrict which events that should trigger the `listener` to be called.
+     *
+     * @param listener the function that will be called when the event fires
+     * @param scope the angular `$scope` that will limit the lifetime of the event subscription
+     * @param eventFilter either the specific `IDefaultGetData` instance you want to receive events for or a predicate function that should return true to receive the event
+     * @return a unregistration function that when called will unregister the `listener`
+     */
+    onAfterDataFiltered<T>(listener: IAfterDataFilteredListener<T>, scope: IScope, eventFilter?: EventSelector<T> ): IUnregistrationFunc;
+    /**
+     * Subscribe to receive notification whenever a `ngTableDefaultGetData` instance filters data
+     * Optionally supply an `eventFilter` to restrict which events that should trigger the `listener` to be called.
+     *
+     * @param listener the function that will be called when the event fires
+     * @param eventFilter either the specific `IDefaultGetData` instance you want to receive events for or a predicate function that should return true to receive the event
+     * @return a unregistration function that when called will unregister the `listener`
+     */
+    onAfterDataFiltered<T>(listener: IAfterDataFilteredListener<T>, eventFilter?: EventSelector<T> ): IUnregistrationFunc; 
+    /**
+     * Subscribe to receive notification whenever a `ngTableDefaultGetData` instance orders data
+     * Optionally supply an `eventFilter` to restrict which events that should trigger the `listener` to be called.
+     *
+     * @param listener the function that will be called when the event fires
+     * @param scope the angular `$scope` that will limit the lifetime of the event subscription
+     * @param eventFilter either the specific `IDefaultGetData` instance you want to receive events for or a predicate function that should return true to receive the event
+     * @return a unregistration function that when called will unregister the `listener`
+     */
+    onAfterDataSorted<T>(listener: IAfterDataSortedListener<T>, scope: IScope, eventFilter?: EventSelector<T> ): IUnregistrationFunc;
+    /**
+     * Subscribe to receive notification whenever a `ngTableDefaultGetData` instance orders data
+     * Optionally supply an `eventFilter` to restrict which events that should trigger the `listener` to be called.
+     *
+     * @param listener the function that will be called when the event fires
+     * @param eventFilter either the specific `IDefaultGetData` instance you want to receive events for or a predicate function that should return true to receive the event
+     * @return a unregistration function that when called will unregister the `listener`
+     */
+    onAfterDataSorted<T>(listener: IAfterDataSortedListener<T>, eventFilter?: EventSelector<T> ): IUnregistrationFunc;
 
     publishAfterCreated<T>(publisher: INgTableParams<T>): void;
     publishAfterReloadData<T>(publisher: INgTableParams<T>, newData: T[], oldData: T[]): void;
     publishDatasetChanged<T>(publisher: INgTableParams<T>, newDataset: T[], oldDataset: T[]): void;
     publishPagesChanged<T>(publisher: INgTableParams<T>, newPages: IPageButton[], oldPages: IPageButton[]): void;
+    publishAfterDataFiltered<T>(publisher: IDefaultGetData<T>, params: INgTableParams<T>, newData: T[]): void;
+    publishAfterDataSorted<T>(publisher: IDefaultGetData<T>, params: INgTableParams<T>, newData: T[]): void;
 }
+

--- a/test/tableParamsSpec.spec.ts
+++ b/test/tableParamsSpec.spec.ts
@@ -2159,5 +2159,87 @@ describe('NgTableParams', () => {
                 expect(events[1]).toEqual('datasetChanged');
             });
         });
+
+        describe('afterDataFiltered', () => {
+            it('should fire when a reload completes - no filter', () => {
+                // given
+                ngTableEventsChannel.onAfterDataFiltered((getData, params, newVal) => {
+                    actualPublisher = params;
+                    actualEventArgs = [newVal];
+                });
+                var data = [1,2,3];
+                var params = createNgTableParams({ count: 5 }, { counts: [5, 10], dataset: data });
+
+                // when
+                params.reload();
+                scope.$digest();
+
+                // then
+                expect(actualPublisher).toBe(params);
+                expect(actualEventArgs).toEqual([data]);
+            });
+
+            it('should fire when a reload completes and the data is filtered', () => {
+                // given
+                ngTableEventsChannel.onAfterDataFiltered((getData, params, newVal) => {
+                    actualPublisher = params;
+                    actualEventArgs = [newVal];
+                });
+
+                var initialDs  = [10, 10, 101, 5];
+                var expectedDs = [10, 10, 101];  // when filtered with "10"
+                var params = createNgTableParams({ dataset: initialDs });
+                params.filter({ $: "10" });
+                
+                // when
+                params.reload();
+                scope.$digest();
+
+                // then
+                expect(actualPublisher).toBe(params);
+                expect(actualEventArgs).toEqual([expectedDs]);
+            });
+        });
+
+        describe('afterDataSorted', () => {
+            it('should fire when a reload completes - no order', () => {
+                // given
+                ngTableEventsChannel.onAfterDataSorted((getData, params, newVal) => {
+                    actualPublisher = params;
+                    actualEventArgs = [newVal];
+                });
+                var data = [1,2,3];
+                var params = createNgTableParams({ count: 5 }, { counts: [5, 10], dataset: data });
+
+                // when
+                params.reload();
+                scope.$digest();
+
+                // then
+                expect(actualPublisher).toBe(params);
+                expect(actualEventArgs).toEqual([data]);
+            });
+
+            it('should fire when a reload completes and the data is filtered', () => {
+                // given
+                ngTableEventsChannel.onAfterDataSorted((getData, params, newVal) => {
+                    actualPublisher = params;
+                    actualEventArgs = [newVal];
+                });
+
+                var initialDs  = [10, 10, 101, 5];
+                var expectedDs = [10, 10, 101];  // when filtered with "10"
+                var params = createNgTableParams({ dataset: initialDs });
+                params.filter({ $: "10" });
+                
+                // when
+                params.reload();
+                scope.$digest();
+
+                // then
+                expect(actualPublisher).toBe(params);
+                expect(actualEventArgs).toEqual([expectedDs]);
+            });
+        });
     })
 });


### PR DESCRIPTION
… and after it is sorted.

Added new events to the ngTableEventsChannel that fire when the ngTableDefaultGetData filters and

sorts the data. This is usefull when you want to try to export only the filtered data or when you

want to make some real time statistics over the data that is beeing filtered.