### PR TITLE
Fix: Use ng-cloak directive. Allows to Disable css class directives

### DIFF
--- a/src/browser/pager.html
+++ b/src/browser/pager.html
@@ -1,4 +1,4 @@
-<div class="ng-cloak ng-table-pager" ng-if="params.data.length">
+<div class="ng-table-pager" ng-cloak ng-if="params.data.length">
     <div ng-if="params.settings().counts.length" class="ng-table-counts btn-group pull-right">
         <button ng-repeat="count in params.settings().counts" type="button"
                 ng-class="{'active':params.count() == count}"


### PR DESCRIPTION
Hi. [This](https://docs.angularjs.org/guide/production) article recommends to Disable comment and css class directives on production for better performance. But the ng-table-pager uses ng-cloak css directive. This pull request fixes it.